### PR TITLE
Added `import/extensions` rule to require extension in imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -101,6 +101,10 @@
 		"no-console": "off",
 		"no-div-regex": "error",
 		"no-duplicate-imports": "error",
+		"import/extensions": [ 
+			"warn",
+			"always"
+		],
 		"no-extend-native": "error",
 		"no-extra-label": "error",
 		"no-fallthrough": "off",


### PR DESCRIPTION
This PR adds the [`import/extensions` rule](https://github.com/import-js/eslint-plugin-import/blob/3a5ad34ca69a5c3239fff56241eb7e353d87274c/docs/rules/extensions.md) from [`eslint-plugin-imports`](https://github.com/import-js/eslint-plugin-import) to require a file extension in imports.

Example:

```javascript
// Correct:
import something from './another-file.js';

// Incorrect: 
// Missing file extension "js" for "./another-file"
import something from './another-file';
```