### PR TITLE
Ignore unused vars that start with `_`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -89,7 +89,12 @@
 			"error",
 			"unix"
 		],
-		"no-unused-vars": "warn",
+		"no-unused-vars": [
+			"warn",
+			{
+				"varsIgnorePattern": "^_"
+			}
+		],
 		"no-alert": "error",
 		"no-caller": "error",
 		"no-confusing-arrow": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -92,7 +92,7 @@
 		"no-unused-vars": [
 			"warn",
 			{
-				"varsIgnorePattern": "^_"
+				"varsIgnorePattern": "^_$"
 			}
 		],
 		"no-alert": "error",


### PR DESCRIPTION
This addition allows unused variables that start with an underscore. Consider the following examples:

```javascript
const [ _, spread1, spread2 ] = array;
const unusedArg = (_, arg2) => console.log(arg2);
for (const [ _, value ] of map.entries()) {...}
```

See also: Johbog/eslint-config-svelte3#20.